### PR TITLE
fix: resolve Dockerfile merge conflicts and copy scripts before pnpm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,34 @@
-<<<<<<< HEAD
-
 # Multi-stage build for Audityzer
+# Stage 1: Builder
 FROM node:20-alpine AS builder
 
+# Install pnpm
+RUN npm install -g pnpm
+
 # Set working directory
-=======
-FROM node:20-slim as builder
-
->>>>>>> 9fcef16aa3870634216e27d04154ec98e4c712a8
 WORKDIR /app
-COPY package*.json ./
-<<<<<<< HEAD
-COPY tsconfig.json ./
 
-# Install dependencies
-RUN npm ci --only=production
+# Copy package files and scripts needed for postinstall
+COPY package.json pnpm-lock.yaml ./
+COPY scripts/ ./scripts/
+
+# Install dependencies (triggers postinstall which needs scripts/fix-dependencies.js)
+RUN pnpm install --frozen-lockfile --prod
 
 # Copy source code
 COPY src/ ./src/
 COPY bin/ ./bin/
 COPY templates/ ./templates/
 COPY lib/ ./lib/
+COPY tsconfig.json ./
 
 # Build the application
-RUN npm run build
+RUN pnpm run build
 
-# Production stage
+# Stage 2: Production
 FROM node:20-alpine AS production
 
-# Install security updates
+# Install security updates and runtime deps
 RUN apk update && apk upgrade && apk add --no-cache \
     dumb-init \
     curl \
@@ -45,7 +45,7 @@ WORKDIR /app
 COPY --from=builder --chown=audityzer:audityzer /app/node_modules ./node_modules
 COPY --from=builder --chown=audityzer:audityzer /app/dist ./dist
 COPY --from=builder --chown=audityzer:audityzer /app/bin ./bin
-COPY --from=builder --chown=audityzer:audityzer /app/package*.json ./
+COPY --from=builder --chown=audityzer:audityzer /app/package.json ./
 
 # Copy additional runtime files
 COPY --chown=audityzer:audityzer templates/ ./templates/
@@ -71,15 +71,3 @@ ENTRYPOINT ["dumb-init", "--"]
 
 # Start the application
 CMD ["./scripts/start.sh"]
-=======
-RUN npm install
-COPY . .
-RUN npm run build
-
-FROM node:20-slim
-WORKDIR /app
-COPY --from=builder /app/dist ./dist
-RUN npm ci --omit=dev
-
-CMD ["node", "dist/cli.js"]
->>>>>>> 9fcef16aa3870634216e27d04154ec98e4c712a8


### PR DESCRIPTION
## Root Cause

The CI build was failing with:
```
Error: Cannot find module '/app/scripts/fix-dependencies.js'
```

This was caused by two issues:

1. **Dockerfile had unresolved git merge conflicts** (`<<<<<<< HEAD`, `=======`, `>>>>>>>`) with literal `<br>` tags instead of newlines, making the file invalid.
2. **`scripts/` directory was not copied before `pnpm install`** — the `postinstall` hook in `package.json` calls `node scripts/fix-dependencies.js`, but the scripts directory was only available after source code copy (after install).

## Fix

- Rewrote Dockerfile with clean multi-stage build (no merge conflict markers)
- Moved `COPY scripts/ ./scripts/` BEFORE `RUN pnpm install --frozen-lockfile --prod`
- Switched builder base image to `node:20-alpine` with explicit pnpm installation

## Testing

This fix ensures the Docker build stage sequence is:
1. Copy `package.json` + `pnpm-lock.yaml`
2. Copy `scripts/` (needed for postinstall hook)
3. Run `pnpm install` (postinstall can now find `scripts/fix-dependencies.js`)
4. Copy remaining source files
5. Build application

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing Docker builds and improves runtime by cleaning the Dockerfile, copying `scripts/` before `pnpm install`, and updating startup/health checks. Postinstall now finds `scripts/fix-dependencies.js`, and the container runs on port 5000.

- **Bug Fixes**
  - Rebuilt a clean multi-stage Dockerfile on `node:20-alpine` and installed `pnpm`.
  - Copied `scripts/` before `pnpm install --frozen-lockfile` and limited source copies to required dirs.
  - In production, copied built artifacts and `node_modules` from the builder, run as non-root with `dumb-init`, exposed 5000, added a healthcheck, and start via `./scripts/start.sh`.

<sup>Written for commit 678eef33c65c5553f92bc4c2469d20623d42e3f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

