### PR TITLE
Fix Dockerfile: resolve merge conflicts, clean multi-stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,10 @@
-<<<<<<< HEAD
-
 # Multi-stage build for Audityzer
 FROM node:20-alpine AS builder
 
 # Set working directory
-=======
-FROM node:20-slim as builder
-
->>>>>>> 9fcef16aa3870634216e27d04154ec98e4c712a8
 WORKDIR /app
+
 COPY package*.json ./
-<<<<<<< HEAD
 COPY tsconfig.json ./
 
 # Install dependencies
@@ -31,55 +25,28 @@ FROM node:20-alpine AS production
 # Install security updates
 RUN apk update && apk upgrade && apk add --no-cache \
     dumb-init \
-    curl \
     && rm -rf /var/cache/apk/*
 
 # Create non-root user
-RUN addgroup -g 1001 -S audityzer && \
+RUN addgroup -g 1001 -S nodejs && \
     adduser -S audityzer -u 1001
 
-# Set working directory
 WORKDIR /app
 
-# Copy built application from builder stage
-COPY --from=builder --chown=audityzer:audityzer /app/node_modules ./node_modules
-COPY --from=builder --chown=audityzer:audityzer /app/dist ./dist
-COPY --from=builder --chown=audityzer:audityzer /app/bin ./bin
-COPY --from=builder --chown=audityzer:audityzer /app/package*.json ./
+# Copy built artifacts
+COPY --from=builder --chown=audityzer:nodejs /app/node_modules ./node_modules
+COPY --from=builder --chown=audityzer:nodejs /app/bin ./bin
+COPY --from=builder --chown=audityzer:nodejs /app/src ./src
+COPY --from=builder --chown=audityzer:nodejs /app/templates ./templates
+COPY --from=builder --chown=audityzer:nodejs /app/lib ./lib
+COPY --chown=audityzer:nodejs package*.json ./
 
-# Copy additional runtime files
-COPY --chown=audityzer:audityzer templates/ ./templates/
-COPY --chown=audityzer:audityzer lib/ ./lib/
-COPY --chown=audityzer:audityzer scripts/healthcheck.sh ./scripts/
-COPY --chown=audityzer:audityzer scripts/start.sh ./scripts/
-
-# Make scripts executable
-RUN chmod +x ./scripts/*.sh
-
-# Switch to non-root user
 USER audityzer
 
-# Expose port
-EXPOSE 5000
+EXPOSE 3000
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD ./scripts/healthcheck.sh
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+    CMD node -e "require('http').get('http://localhost:3000/', (r) => process.exit(r.statusCode === 200 ? 0 : 1))" || exit 1
 
-# Use dumb-init to handle signals properly
 ENTRYPOINT ["dumb-init", "--"]
-
-# Start the application
-CMD ["./scripts/start.sh"]
-=======
-RUN npm install
-COPY . .
-RUN npm run build
-
-FROM node:20-slim
-WORKDIR /app
-COPY --from=builder /app/dist ./dist
-RUN npm ci --omit=dev
-
-CMD ["node", "dist/cli.js"]
->>>>>>> 9fcef16aa3870634216e27d04154ec98e4c712a8
+CMD ["node", "bin/audityzer.js", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ USER audityzer
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD node -e "require('http').get('http://localhost:3000/', (r) => process.exit(r.statusCode === 200 ? 0 : 1))" || exit 1
+    CMD node -e "require('http').get('http://localhost:3000/', (r) => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"
 
 ENTRYPOINT ["dumb-init", "--"]
-CMD ["node", "bin/audityzer.js", "start"]
+CMD ["node", "bin/audityzer.js"]


### PR DESCRIPTION
Refactor Dockerfile to use node:20-alpine, update user permissions, and change CMD to start the application correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve merge conflicts and streamline the multi-stage Docker build on `node:20-alpine`. Fix the CMD entrypoint and healthcheck for reliable startup on port 3000 with a non-root runtime.

- **Refactors**
  - Use `node:20-alpine` for both stages; install security updates and `dumb-init`.
  - Run as non-root user `audityzer` (group `nodejs`); fix file ownership to `audityzer:nodejs`.
  - Copy only needed artifacts from the builder: `node_modules`, `bin`, `src`, `templates`, `lib`, and `package*.json`.
  - Set `CMD ["node", "bin/audityzer.js"]` and keep `ENTRYPOINT ["dumb-init", "--"]`; remove shell scripts.
  - Expose `3000` and add a Node-based `HEALTHCHECK` with proper error handling and a longer start period.

<sup>Written for commit 8141c52a533135bee7caa3a6f4e0b4f4ee10d1e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

