### PR TITLE
ci: add merge-main workflow to resolve PR #132 conflicts

### DIFF
--- a/.github/workflows/merge-main.yml
+++ b/.github/workflows/merge-main.yml
@@ -1,0 +1,30 @@
+name: Merge main into defense-audit
+on:
+  workflow_dispatch:
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout defense-audit
+        uses: actions/checkout@v4
+        with:
+          ref: defense-audit
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Merge main into defense-audit
+        run: |
+          git fetch origin main
+          git merge origin/main --no-edit -X ours || true
+          # Regenerate package-lock.json to resolve lockfile conflicts
+          if [ -f package.json ]; then
+            npm install --package-lock-only 2>/dev/null || true
+          fi
+          git add -A
+          git diff --cached --quiet || git commit -m "chore: merge main into defense-audit, regenerate package-lock.json"
+          git push origin defense-audit


### PR DESCRIPTION
This workflow automates the process of merging the main branch into the defense-audit branch and regenerates the package-lock.json if necessary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual GitHub Actions workflow to sync `defense-audit` with `main` and help resolve PR #132 merge conflicts.

- **New Features**
  - Merges `main` into `defense-audit` on demand and auto-commits/pushes using the bot.
  - Regenerates `package-lock.json` via `npm install --package-lock-only` to fix lockfile conflicts.

<sup>Written for commit a4aef4bdbe73cbc73b2532e31852bdcdc7d30809. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

