### PR TITLE
fix: remove "type": "module" from main branch for Render deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "audityzer",
   "version": "1.1.3",
   "description": "Comprehensive Web3 security testing toolkit for DeFi applications and smart contracts",
-  "type": "module",
+
   "main": "src/index.js",
   "bin": {
     "audityzer": "bin/audityzer.js"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed "type": "module" from package.json to switch back to CommonJS and fix Render deploy failures. Node on Render now runs src/index.js and bin/audityzer.js without ESM loader errors.

<sup>Written for commit dd85c379685e638698284a5e8e40e2c3ac18607f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

