### PR TITLE
fix: convert firebase.js ESM imports to CommonJS require()

### DIFF
--- a/src/core/services/firebase.js
+++ b/src/core/services/firebase.js
@@ -1,9 +1,9 @@
-import { initializeApp } from 'firebase/app';
-import { getFirestore } from 'firebase/firestore';
-import { getAuth } from 'firebase/auth';
-import { getStorage } from 'firebase/storage';
-import fs from 'fs-extra';
-import path from 'path';
+const { initializeApp } = require('firebase/app');
+const { getFirestore } = require('firebase/firestore');
+const { getAuth } = require('firebase/auth');
+const { getStorage } = require('firebase/storage');
+const fs = require('fs-extra');
+const path = require('path');
 
 // Check for environment variables first
 const firebaseConfig = {
@@ -37,4 +37,4 @@ const db = getFirestore(app);
 const auth = getAuth(app);
 const storage = getStorage(app);
 
-export { app, db, auth, storage, firebaseConfig }; 
+module.exports = { app, db, auth, storage };


### PR DESCRIPTION
Updated import statements to use CommonJS require syntax.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched `src/core/services/firebase.js` from ESM to CommonJS so it works in Node/CommonJS builds. Replaced `import`/`export` with `require()` and `module.exports` for `firebase/*`, `fs-extra`, and `path`.

- **Bug Fixes**
  - Prevents CommonJS runtime errors (e.g., "Cannot use import statement outside a module") when loading Firebase services.

- **Migration**
  - `firebaseConfig` is no longer exported. Update imports to use `{ app, db, auth, storage }` only.

<sup>Written for commit f47bf803a2d318dd0f0e566aecc2c66fb93a7537. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

