### PR TITLE
fix: remove .default from reportService require in src/index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const reportService = require('./core/services/report-service').default;
+const reportService = require('./core/services/report-service').;
 const { app, db, auth, storage } = require('./core/services/firebase');
 
 // Export the Firebase app and services


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the report service import in `src/index.js` by removing `.default` from `require('./core/services/report-service')` to use the module’s CommonJS export and prevent undefined import errors.

<sup>Written for commit 3e94ee76ea956ebb3c7c9326ad91430ff67ead3e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

