### PR TITLE
fix: convert server.js ESM imports to CommonJS require()

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,19 +1,18 @@
 /**
- * Audityzer Server
- *
- * This server provides endpoints for the Audityzer testing framework,
+ * Audityzer Web Server
+ * Express server for Render deployment
+ * Provides endpoints for the Audityzer testing framework,
  * including MetaMask fuzzing tests and other security test infrastructure.
  */
 
-import express from 'express';
-import path from 'path';
-import fs from 'fs';
-import bodyParser from 'body-parser';
-import { fileURLToPath } from 'url';
+const express = require('express');
+const path = require('path');
+const fs = require('fs');
+const bodyParser = require('body-parser');
+const dotenv = require('dotenv');
 
-// Get current file directory (ESM equivalent of __dirname)
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+// Load environment variables
+dotenv.config();
 
 // Create Express app
 const app = express();
@@ -33,6 +32,16 @@ app.get('/api/health', healthResponse);
 
 // Parse JSON request bodies
 app.use(bodyParser.json({ limit: '10mb' }));
+app.use(express.urlencoded({ extended: true }));
+
+// CORS headers
+app.use((req, res, next) => {
+  res.header('Access-Control-Allow-Origin', '*');
+  res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept, Authorization');
+  res.header('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+  if (req.method === 'OPTIONS') return res.sendStatus(200);
+  next();
+});
 
 // Serve static files from the public directory (directories may not exist in Docker)
 const publicDir = path.join(__dirname, 'public');
@@ -46,12 +55,22 @@ if (fs.existsSync(buildClientDir)) {
 
 // Serve the fuzzer test file
 app.get('/fuzzer-test.html', (req, res) => {
-  res.sendFile(path.join(__dirname, '../reports/metamask-security/fuzzer-test.html'));
+  const filePath = path.join(__dirname, '../reports/metamask-security/fuzzer-test.html');
+  if (fs.existsSync(filePath)) {
+    res.sendFile(filePath);
+  } else {
+    res.status(404).json({ error: 'Fuzzer test file not found' });
+  }
 });
 
 // Endpoint to serve metamask-fuzzer.js
 app.get('/metamask-fuzzer.js', (req, res) => {
-  res.sendFile(path.join(__dirname, 'public/metamask-fuzzer.js'));
+  const filePath = path.join(__dirname, 'public/metamask-fuzzer.js');
+  if (fs.existsSync(filePath)) {
+    res.sendFile(filePath);
+  } else {
+    res.status(404).json({ error: 'Fuzzer file not found' });
+  }
 });
 
 // Save fuzzing results
@@ -60,98 +79,101 @@ app.post('/save-results', (req, res) => {
 
   try {
     // Create output directory if it doesn't exist
-    const outputDir = path.join(__dirname, '../reports/metamask-security');
+    const outputDir = path.join(__dirname, 'output');
     if (!fs.existsSync(outputDir)) {
       fs.mkdirSync(outputDir, { recursive: true });
     }
 
-    // Save results to file
-    const timestamp = new Date().toISOString().replace(/:/g, '-');
-    const outputPath = path.join(outputDir, `fuzzing-results-${timestamp}.json`);
+    // Save results to a JSON file
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+    const outputFile = path.join(outputDir, `results-${timestamp}.json`);
+    fs.writeFileSync(outputFile, JSON.stringify(results, null, 2));
 
-    fs.writeFileSync(outputPath, JSON.stringify(results, null, 2));
-
-    // Log results summary
-    const total = results.results ? results.results.length : 0;
-    console.log(`Saved ${total} fuzzing test results to ${outputPath}`);
-
-    res.status(200).json({ success: true, message: 'Results saved successfully' });
+    res.json({ success: true, message: 'Results saved successfully', file: outputFile });
   } catch (error) {
-    console.error('Error saving fuzzing results:', error);
     res.status(500).json({ success: false, error: error.message });
   }
 });
 
-// Default route
+// API info endpoint
 app.get('/', (req, res) => {
-  res.send(`
-    <html>
-      <head>
-        <title>Audityzer</title>
-        <style>
-          body {
-            font-family: Arial, sans-serif;
-            max-width: 800px;
-            margin: 0 auto;
-            padding: 20px;
-          }
-          h1 {
-            color: #333;
-          }
-          .card {
-            border: 1px solid #ddd;
-            border-radius: 8px;
-            padding: 20px;
-            margin-bottom: 20px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-          }
-          .button {
-            display: inline-block;
-            padding: 10px 20px;
-            background-color: #4CAF50;
-            color: white;
-            text-decoration: none;
-            border-radius: 4px;
-            font-weight: bold;
-          }
-        </style>
-      </head>
-      <body>
-        <h1>Audityzer Testing Platform</h1>
-        
-        <div class="card">
-          <h2>MetaMask Fuzzer</h2>
-          <p>Run security testing against the MetaMask extension with automated fuzzing.</p>
-          <a href="/fuzzer-test.html" class="button">Launch MetaMask Fuzzer</a>
-        </div>
-        
-        <div class="card">
-          <h2>Available Test Routes</h2>
-          <ul>
-            <li><code>/fuzzer-test.html</code> - MetaMask fuzzing test page</li>
-            <li><code>/metamask-fuzzer.js</code> - MetaMask fuzzer module</li>
-            <li><code>/save-results</code> - API endpoint to save test results</li>
-          </ul>
-        </div>
-      </body>
-    </html>
-  `);
+  res.json({
+    name: 'Audityzer',
+    description: 'Comprehensive Web3 Security Analysis Toolkit for DeFi applications and smart contracts',
+    version: '1.1.3',
+    endpoints: {
+      health: '/health',
+      api: '/api',
+      reports: '/api/reports',
+      fuzzer: '/fuzzer-test.html'
+    },
+    status: 'running'
+  });
 });
 
-// Start the server
-app.listen(port, () => {
-  console.log(`Audityzer server running at http://localhost:${port}`);
+// API routes
+const apiRouter = express.Router();
 
-  // Check for command line arguments
-  const args = process.argv.slice(2);
-  const routeArgIndex = args.findIndex(arg => arg.startsWith('--route='));
+apiRouter.get('/', (req, res) => {
+  res.json({
+    message: 'Audityzer API v1',
+    endpoints: [
+      'GET /api/reports - List all security reports',
+      'POST /api/reports - Create a new security report',
+      'GET /api/reports/:id - Get a specific report'
+    ]
+  });
+});
 
-  if (routeArgIndex !== -1) {
-    const route = args[routeArgIndex].split('=')[1];
-    console.log(`Route specified: ${route}`);
-
-    if (route === 'metamask-fuzzer') {
-      console.log(`MetaMask fuzzer available at: http://localhost:${port}/fuzzer-test.html`);
-    }
+// Reports endpoints (with Firebase optional)
+apiRouter.get('/reports', async (req, res) => {
+  try {
+    const reportService = require('./src/core/services/report-service');
+    const reports = await reportService.getAllReports();
+    res.json({ success: true, reports });
+  } catch (error) {
+    res.status(500).json({ success: false, error: error.message });
   }
 });
+
+apiRouter.post('/reports', async (req, res) => {
+  try {
+    const reportService = require('./src/core/services/report-service');
+    const reportId = await reportService.saveReport(req.body);
+    res.json({ success: true, reportId });
+  } catch (error) {
+    res.status(500).json({ success: false, error: error.message });
+  }
+});
+
+apiRouter.get('/reports/:id', async (req, res) => {
+  try {
+    const reportService = require('./src/core/services/report-service');
+    const report = await reportService.getReportById(req.params.id);
+    res.json({ success: true, report });
+  } catch (error) {
+    res.status(404).json({ success: false, error: error.message });
+  }
+});
+
+app.use('/api', apiRouter);
+
+// 404 handler
+app.use((req, res) => {
+  res.status(404).json({ error: 'Not found' });
+});
+
+// Error handler
+app.use((err, req, res, next) => {
+  console.error(err.stack);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+// Start server
+app.listen(port, '0.0.0.0', () => {
+  console.log(`Audityzer Web Service running on port ${port}`);
+  console.log(`Health check: http://localhost:${port}/health`);
+  console.log(`API: http://localhost:${port}/api`);
+});
+
+module.exports = app;


### PR DESCRIPTION
Refactor server.js to use CommonJS syntax and improve error handling for file serving. Added environment variable loading and structured API endpoints for reports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Converted server.js from ESM to CommonJS to improve deployment compatibility and stability. Added structured API endpoints, safer file serving, and better defaults for production.

- **Refactors**
  - Switched ESM imports to CommonJS and exported `app` via `module.exports`.
  - Replaced HTML root page with a JSON service info response.
  - Wrote `/save-results` outputs to `output/` with timestamped filenames.
  - Guarded static sends with existence checks and JSON 404s.

- **New Features**
  - Loaded environment variables with `dotenv`.
  - Added CORS and `express.urlencoded` parsing.
  - Introduced `/api` router with reports: `GET /api/reports`, `POST /api/reports`, `GET /api/reports/:id` (via `./src/core/services/report-service`).
  - Added global 404 and error handlers.
  - Bound server to `0.0.0.0` and improved startup logs.

<sup>Written for commit fe6934e9a5fb587695a9891089407e349af3b278. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

