### PR TITLE
fix: P0 - railway startCommand use node server.js instead of non-exis…

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -7,7 +7,7 @@ builder = "NIXPACKS"
 buildCommand = "pnpm install --no-frozen-lockfile"
 
 [deploy]
-startCommand = "node bin/audityzer.js start"
+startCommand = "node server.js"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"


### PR DESCRIPTION
…tent bin handler

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Railway start command to use node server.js, fixing deploys that failed due to a non-existent bin handler.

- **Bug Fixes**
  - Updated `railway.toml` `[deploy].startCommand` to `node server.js`.
  - Resolves start failures caused by missing `bin/audityzer.js`.

<sup>Written for commit b4eb41c2d08c6eac37e1056422c1d9e0b30ded17. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

