### PR TITLE
Remove personal email from outreach-templates.md

### DIFF
--- a/docs/outreach-templates.md
+++ b/docs/outreach-templates.md
@@ -90,7 +90,6 @@ Live Demo: https://audityzer.onrender.com
 Best regards,
 Igor Rihor
 Founder, AuditorSEC
-rigoryanych@icloud.com
 ```
 
 ---
@@ -126,7 +125,7 @@ rigoryanych@icloud.com
 ## AWS Activate Application Notes
 
 **Organization**: AuditorSEC (AuditorSEC Ltd)
-**AWS Account**: rigoryanych@icloud.com
+**AWS Account**: [your-email@domain.com]
 **Company ID (PIC)**: 868176676
 **VAT**: 46077399
 **Use Case**: Kubernetes (EKS) for Audityzer Engine, RDS for report storage, Lambda for async scan workers


### PR DESCRIPTION
Updated email address to a placeholder in outreach templates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a personal email from outreach templates and replaced it with a placeholder to prevent exposing private contact info. Removed the email line in the sign-off and set the AWS Account field to [your-email@domain.com].

<sup>Written for commit 23bddbb7be95718c27a8330a598fc1dea23e23b2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

