### PR TITLE
resolve: update railway.toml - use NIXPACKS with health check

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,10 +1,18 @@
+# Railway deployment configuration for Audityzer
+# Monorepo: contracts/indexer/api/web (pnpm workspace)
+# Docs: https://docs.railway.app/reference/config-as-code
+
 [build]
-builder = "DOCKERFILE"
-dockerfilePath = "Dockerfile"
+builder = "NIXPACKS"
+buildCommand = "pnpm install --no-frozen-lockfile"
 
 [deploy]
 startCommand = "node server.js"
+healthcheckPath = "/health"
+healthcheckTimeout = 300
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10
-healthcheckPath = "/"
-healthcheckTimeout = 30
+numReplicas = 1
+
+[service]
+internalPort = 3000


### PR DESCRIPTION
Updated builder and deployment settings in railway.toml.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Railway to NIXPACKS with a `/health` endpoint to improve build simplicity and deploy reliability. Sets service defaults for a stable runtime.

- **Refactors**
  - Use NIXPACKS builder with `pnpm install --no-frozen-lockfile`.
  - Add health checks at `/health` and increase timeout to 300s.
  - Define service defaults: `internalPort` 3000 and `numReplicas` 1; keep `startCommand` and restart policy.

<sup>Written for commit 8f7e10430ec257306d78da88f337313f62d5e3d4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

