### PR TITLE
resolve: fix netlify.toml CSP - add img-src and sync with safe-improv…

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -29,7 +29,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' data: https:; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:;"
 
 [[headers]]
   for = "/assets/*"


### PR DESCRIPTION
…ements

Updated Content-Security-Policy to allow images from 'self' and data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CSP in `netlify.toml` to add an img-src directive allowing images from self, data:, and https:. This fixes blocked images and removes CSP errors for CDN and data-URI images.

<sup>Written for commit 466bdbf1aacae7fbee194a1bc0906ceba2d06436. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

