### PR TITLE
feat: update docker-compose.yml — full AuditorSEC stack: API + MinIO …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,241 +1,94 @@
+# docker-compose.yml -- AuditorSEC self-hosted stack
+# BRAVE1 TRL4 PoC | 2026-04-19
+# Services: FastAPI API + MinIO + Prometheus + Grafana
 
-version: '3.8'
+version: '3.9'
 
 services:
-  # Main Audityzer Application
-  audityzer-app:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: production
-    container_name: audityzer-app
-    restart: unless-stopped
-    ports:
-      - "3000:3000"
-    environment:
-      - NODE_ENV=production
-      - DATABASE_URL=postgresql://audityzer:${DB_PASSWORD}@postgres:5432/audityzer
-      - REDIS_URL=redis://redis:6379
-      - MCP_SERVER_URL=http://mcp-server:8080
-      - JWT_SECRET=${JWT_SECRET}
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
-      - SLACK_WEBHOOK=${SLACK_WEBHOOK}
-    depends_on:
-      - postgres
-      - redis
-      - mcp-server
-    networks:
-      - audityzer-network
-    volumes:
-      - ./logs:/app/logs
-      - ./reports:/app/reports
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/health"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 40s
 
-  # MCP Server for AI Integration
-  mcp-server:
-    build:
-      context: .
-      dockerfile: Dockerfile.mcp
-    container_name: audityzer-mcp
+  api:
+    build: .
+    container_name: auditorsec-api
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      - "8000:8000"
     environment:
-      - NODE_ENV=production
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
-      - DATABASE_URL=postgresql://audityzer:${DB_PASSWORD}@postgres:5432/audityzer
+      - MINIO_ENDPOINT=minio:9000
+      - MINIO_ACCESS_KEY=${MINIO_ACCESS_KEY:-minioadmin}
+      - MINIO_SECRET_KEY=${MINIO_SECRET_KEY:-minioadmin}
+      - MINIO_SECURE=false
     depends_on:
-      - postgres
-    networks:
-      - audityzer-network
-    volumes:
-      - ./ai-models:/app/models
+      minio:
+        condition: service_healthy
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 10s
+    networks:
+      - auditorsec
 
-  # PostgreSQL Database
-  postgres:
-    image: postgres:15-alpine
-    container_name: audityzer-postgres
+  minio:
+    image: minio/minio:latest
+    container_name: auditorsec-minio
     restart: unless-stopped
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
     environment:
-      - POSTGRES_DB=audityzer
-      - POSTGRES_USER=audityzer
-      - POSTGRES_PASSWORD=${DB_PASSWORD}
-      - POSTGRES_INITDB_ARGS=--encoding=UTF-8 --lc-collate=C --lc-ctype=C
+      - MINIO_ROOT_USER=${MINIO_ACCESS_KEY:-minioadmin}
+      - MINIO_ROOT_PASSWORD=${MINIO_SECRET_KEY:-minioadmin}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
-      - ./scripts/init-db.sql:/docker-entrypoint-initdb.d/init-db.sql
-    networks:
-      - audityzer-network
-    ports:
-      - "5432:5432"
+      - minio_data:/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U audityzer -d audityzer"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
-
-  # Redis Cache
-  redis:
-    image: redis:7-alpine
-    container_name: audityzer-redis
-    restart: unless-stopped
-    command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD}
-    volumes:
-      - redis_data:/data
-    networks:
-      - audityzer-network
-    ports:
-      - "6379:6379"
-    healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
-      interval: 10s
-      timeout: 3s
-      retries: 5
-
-  # Nginx Reverse Proxy
-  nginx:
-    image: nginx:alpine
-    container_name: audityzer-nginx
-    restart: unless-stopped
-    ports:
-      - "80:80"
-      - "443:443"
-    volumes:
-      - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./nginx/ssl:/etc/nginx/ssl
-      - ./nginx/logs:/var/log/nginx
-    depends_on:
-      - audityzer-app
-    networks:
-      - audityzer-network
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost/health"]
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
+      start_period: 15s
+    networks:
+      - auditorsec
 
-  # Monitoring with Prometheus
   prometheus:
     image: prom/prometheus:latest
-    container_name: audityzer-prometheus
+    container_name: auditorsec-prometheus
     restart: unless-stopped
     ports:
       - "9090:9090"
     volumes:
-      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
-      - '--storage.tsdb.path=/prometheus'
-      - '--web.console.libraries=/etc/prometheus/console_libraries'
-      - '--web.console.templates=/etc/prometheus/consoles'
-      - '--storage.tsdb.retention.time=200h'
-      - '--web.enable-lifecycle'
+      - '--storage.tsdb.retention.time=30d'
     networks:
-      - audityzer-network
+      - auditorsec
 
-  # Grafana for Visualization
   grafana:
     image: grafana/grafana:latest
-    container_name: audityzer-grafana
+    container_name: auditorsec-grafana
     restart: unless-stopped
     ports:
       - "3001:3000"
     environment:
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD}
+      - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-auditorsec2026}
       - GF_USERS_ALLOW_SIGN_UP=false
     volumes:
       - grafana_data:/var/lib/grafana
-      - ./monitoring/grafana/dashboards:/etc/grafana/provisioning/dashboards
-      - ./monitoring/grafana/datasources:/etc/grafana/provisioning/datasources
     depends_on:
       - prometheus
     networks:
-      - audityzer-network
-
-  # Node Exporter for System Metrics
-  node-exporter:
-    image: prom/node-exporter:latest
-    container_name: audityzer-node-exporter
-    restart: unless-stopped
-    ports:
-      - "9100:9100"
-    volumes:
-      - /proc:/host/proc:ro
-      - /sys:/host/sys:ro
-      - /:/rootfs:ro
-    command:
-      - '--path.procfs=/host/proc'
-      - '--path.rootfs=/rootfs'
-      - '--path.sysfs=/host/sys'
-      - '--collector.filesystem.mount-points-exclude=^/(sys|proc|dev|host|etc)($$|/)'
-    networks:
-      - audityzer-network
-
-  # Community Bot
-  community-bot:
-    build:
-      context: .
-      dockerfile: Dockerfile.bot
-    container_name: audityzer-community-bot
-    restart: unless-stopped
-    environment:
-      - NODE_ENV=production
-      - DISCORD_TOKEN=${DISCORD_TOKEN}
-      - DISCORD_GUILD_ID=${DISCORD_GUILD_ID}
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
-      - SLACK_WEBHOOK=${SLACK_WEBHOOK}
-    volumes:
-      - ./logs:/app/logs
-    networks:
-      - audityzer-network
-    depends_on:
-      - audityzer-app
-
-  # Growth Tracker (Scheduled Job)
-  growth-tracker:
-    build:
-      context: .
-      dockerfile: Dockerfile.tracker
-    container_name: audityzer-growth-tracker
-    restart: unless-stopped
-    environment:
-      - GITHUB_TOKEN=${GITHUB_TOKEN}
-      - ANALYTICS_KEY=${ANALYTICS_KEY}
-      - SLACK_WEBHOOK=${SLACK_WEBHOOK}
-      - DATABASE_URL=postgresql://audityzer:${DB_PASSWORD}@postgres:5432/audityzer
-    volumes:
-      - ./reports:/app/reports
-      - ./logs:/app/logs
-    networks:
-      - audityzer-network
-    depends_on:
-      - postgres
-
-networks:
-  audityzer-network:
-    driver: bridge
-    ipam:
-      config:
-        - subnet: 172.20.0.0/16
+      - auditorsec
 
 volumes:
-  postgres_data:
-    driver: local
-  redis_data:
-    driver: local
+  minio_data:
   prometheus_data:
-    driver: local
   grafana_data:
-    driver: local
+
+networks:
+  auditorsec:
+    driver: bridge


### PR DESCRIPTION
…+ Prometheus + Grafana

Updated docker-compose version and modified service configurations, including health checks and environment variables for various services.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rebuilt docker-compose into a lean AuditorSEC stack: `api` + `minio/minio` + `prom/prometheus` + `grafana/grafana`. Upgrades to 3.9, adds health checks and sensible defaults, and removes unused services.

- New Features
  - `api` on 8000 with `/health`; depends on MinIO; env: `OPENAI_API_KEY`, `MINIO_*`.
  - `minio/minio` with console on 9001, persistent `minio_data`, health check.
  - `prom/prometheus` using `./prometheus.yml` (read-only) with 30d retention.
  - `grafana/grafana` with env-configured admin, persistent `grafana_data`.
  - Single `auditorsec` network; simplified volumes.

- Migration
  - Set `.env`: `OPENAI_API_KEY`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, optional `GF_SECURITY_ADMIN_USER/PASSWORD`.
  - Place Prometheus config at `./prometheus.yml` (path changed from `./monitoring/...`).
  - Exposed ports: 8000 (API), 9000/9001 (MinIO), 9090 (Prometheus), 3001 (Grafana). Run: docker compose up -d.

<sup>Written for commit 14dbacff9cd68505bc1addf0937002d380d42b5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

