### PR TITLE
fix(ci): fix YAML syntax error in ci-cd-clean.yml - add run: to Notif…

### DIFF
--- a/.github/workflows/ci-cd-clean.yml
+++ b/.github/workflows/ci-cd-clean.yml
@@ -1,4 +1,3 @@
-
 name: CI/CD Pipeline
 
 on:
@@ -15,7 +14,7 @@ jobs:
   test:
     name: Test & Build
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -32,7 +31,6 @@ jobs:
     - name: Install dependencies
       run: |
         echo "🔧 Installing dependencies with fallback strategies..."
-        
         # Try npm ci first
         if npm ci --legacy-peer-deps --force; then
           echo "✅ npm ci succeeded"
@@ -109,7 +107,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.ref == 'refs/heads/develop'
-    
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -126,21 +123,11 @@ jobs:
         echo "🚀 Deploying to GitHub Pages staging..."
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        
-        # Create gh-pages branch if it doesn't exist
         git checkout --orphan gh-pages-staging || git checkout gh-pages-staging
-        
-        # Clear existing content
         git rm -rf . || true
-        
-        # Copy build artifacts
         cp -r dist/* . 2>/dev/null || echo "No dist files to copy"
-        
-        # Create staging directory structure
         mkdir -p staging
         cp -r dist/* staging/ 2>/dev/null || echo "No dist files for staging"
-        
-        # Commit and push
         git add .
         git commit -m "Deploy staging from ${{ github.sha }}" || echo "No changes to commit"
         git push origin gh-pages-staging --force || echo "Push failed, continuing..."
@@ -150,7 +137,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     if: github.ref == 'refs/heads/main'
-    
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -167,53 +153,49 @@ jobs:
         echo "🚀 Deploying to GitHub Pages production..."
         git config --global user.name "github-actions[bot]"
         git config --global user.email "github-actions[bot]@users.noreply.github.com"
-        
-        # Create gh-pages branch if it doesn't exist
         git checkout --orphan gh-pages || git checkout gh-pages
-        
-        # Clear existing content
         git rm -rf . || true
-        
-        # Copy build artifacts
         cp -r dist/* . 2>/dev/null || echo "No dist files to copy"
-        
-        # Commit and push
         git add .
         git commit -m "Deploy production from ${{ github.sha }}" || echo "No changes to commit"
         git push origin gh-pages --force || echo "Push failed, continuing..."
 
     - name: Notify deployment success
+      run: |
+        echo "✅ Production deployment successful!"
+        echo "🚀 Application deployed to: https://romanchaa997.github.io/Audityzer"
 
-      backup-to-s3:
+  backup-to-s3:
     name: Backup Build Artifacts to S3
     runs-on: ubuntu-latest
     needs: test
     if: github.ref == 'refs/heads/main' && success()
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Download build artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: build-artifacts
-          path: ./build-backup
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-east-1
-      - name: Upload to S3
-        run: |
-          TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-          aws s3 sync ./build-backup s3://audityzer-backups/builds/${TIMESTAMP}/ --delete
-          echo "✅ Backup uploaded to s3://audityzer-backups/builds/${TIMESTAMP}/"
-      - name: Cleanup old backups
-        run: |
-          aws s3 ls s3://audityzer-backups/builds/ | awk '{print $2}' | sort -r | tail -n +30 | while read dir; do
-            aws s3 rm s3://audityzer-backups/builds/${dir} --recursive
-            echo "🗑️ Deleted old backup: ${dir}"
-          done
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: build-artifacts
+        path: ./build-backup
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    - name: Upload to S3
       run: |
-        echo "✅ Production deployment successful!"
-        echo "🚀 Application deployed to: https://romanchaa997.github.io/Audityzer"
+        TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+        aws s3 sync ./build-backup s3://audityzer-backups/builds/${TIMESTAMP}/ --delete
+        echo "✅ Backup uploaded to s3://audityzer-backups/builds/${TIMESTAMP}/"
+
+    - name: Cleanup old backups
+      run: |
+        aws s3 ls s3://audityzer-backups/builds/ | awk '{print $2}' | sort -r | tail -n +30 | while read dir; do
+          aws s3 rm s3://audityzer-backups/builds/${dir} --recursive
+          echo "🗑️ Deleted old backup: ${dir}"
+        done

--- a/.github/workflows/ci-cd-clean.yml
+++ b/.github/workflows/ci-cd-clean.yml
@@ -161,6 +161,7 @@ jobs:
         git push origin gh-pages --force || echo "Push failed, continuing..."
 
     - name: Notify deployment success
+          if: github.repository_owner == 'romanchaa997' && success()
       run: |
         echo "✅ Production deployment successful!"
         echo "🚀 Application deployed to: https://romanchaa997.github.io/Audityzer"


### PR DESCRIPTION
…y step, remove orphaned block

Refactor CI/CD pipeline to improve deploymen## Fix: YAML syntax error in ci-cd-clean.yml

### Problem
- Step `Notify deployment success` in `deploy-production` job was missing its `run:` key
- This caused a YAML parse error on line 192
- An orphaned `run: |` block existed at the end of the file outside any step context
- Result: 4+ CI startup failures on every push to `safe-improvements`

### Fix
- Added `run: |` with proper echo commands to the `Notify deployment success` step
- Removed the orphaned `run:` block from end of file
- All jobs now have correct YAML structure: `test`, `deploy-staging`, `deploy-production`, `backup-to-s3`

### Impact
Fixes startup failures for: CI Fast Pipeline, Security Auditing CI/CD, Web3FuzzForge CI/CD, Security Quality Gatest steps and add S3 backup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix YAML errors and add a safety guard in `ci-cd-clean.yml` to restore CI startup and ensure production notifications and S3 backups run reliably.

- **Bug Fixes**
  - Added `run:` to the “Notify deployment success” step in `deploy-production`.
  - Added an `if:` guard so the notify step runs only for `romanchaa997` and on success.
  - Removed an orphaned `run: |` block at the end of the file.
  - Fixed `backup-to-s3` job structure by placing steps under the job with proper indentation.

<sup>Written for commit b54e562c7372542c1eccdef07fc8247efa6fa7cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

