### PR TITLE
fix: sync netlify.toml with main to resolve merge conflict

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = "pnpm install --no-frozen-lockfile && pnpm run build"
   publish = "dist"
-  
+
 [build.environment]
   NODE_VERSION = "18"
   GIT_LFS_ENABLED = "false"
@@ -29,7 +29,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' data: https:; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:"
 
 [[headers]]
   for = "/assets/*"

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
   NODE_VERSION = "18"
   GIT_LFS_ENABLED = "false"
   PNPM_FLAGS = "--no-frozen-lockfile"
+    GIT_SUBMODULE_STRATEGY = "none"
 
 # Build settings with correct pnpm commands
 [context.production]


### PR DESCRIPTION
Updated Content-Security-Policy to allow images from https.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs `netlify.toml` with main to resolve the merge conflict. Adds `img-src 'self' data: https:` to the Content-Security-Policy so images load from HTTPS and data URLs, and sets `GIT_SUBMODULE_STRATEGY=none` in the build environment to skip submodule fetching.

<sup>Written for commit 3dd722c21855b3d9bcd4c0dcca491f77aa129e72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

