### PR TITLE
Change pnpm setup to global installation

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -34,10 +34,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
+                run: npm install -g pnpm@9
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-                run: npm install -g pnpm@9
+          run: npm install -g pnpm@9
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 


### PR DESCRIPTION
Replace pnpm/action-setup@v4 (blocked action) with 'npm install -g pnpm@9' to fix CI startup failures in deploy-railway workflow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install `pnpm@9` globally in the `deploy-railway` GitHub Actions workflow, replacing `pnpm/action-setup@v4`, to bypass the blocked action and fix CI startup failures. Also fix YAML indentation for the `run` key in the Setup pnpm step so the command runs correctly.

<sup>Written for commit 74218a325e8104b5632bc1e41ef149e4e0da5d3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

