### PR TITLE
Refactor audit logic and improve fix(api): fix async blocking - use a…

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,11 +2,14 @@
 # AuditorSEC / Audityzer — BRAVE1 TRL4 PoC
 # Branch: safe-improvements | 2026-04-19
 
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-from datetime import datetime, timezone
+import asyncio
+import json
 import os
+from datetime import datetime, timezone
+
 import openai
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
 
 from report import generate_pdf_report
 
@@ -18,12 +21,14 @@ app = FastAPI(
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
+# ── Models ──────────────────────────────────────────────────────────────────────
 
-# ── Models ────────────────────────────────────────────────────────────────────
+LOG_TEXT_MAX_LEN = 8000  # ~2000 tokens; prevents DoS / runaway cost
+
 
 class AuditRequest(BaseModel):
     project_name: str
-    log_text: str
+    log_text: str = Field(..., max_length=LOG_TEXT_MAX_LEN)
     audit_type: str = "health_check"
 
 
@@ -39,7 +44,7 @@ class AuditResponse(BaseModel):
 
 class ReportRequest(BaseModel):
     project_name: str
-    log_text: str
+    log_text: str = Field(..., max_length=LOG_TEXT_MAX_LEN)
     audit_type: str = "health_check"
 
 
@@ -54,27 +59,22 @@ class ReportResponse(BaseModel):
     timestamp: str
 
 
-# ── Core audit logic ──────────────────────────────────────────────────────────
+# ── Core audit logic ─────────────────────────────────────────────────────────────
 
 SYSTEM_PROMPT = """You are AuditorSEC — an expert AI security auditor for Web3 protocols,
-IoT/NEMS sensor systems, and defense-grade infrastructure. Analyze the provided log/description
-and return a structured JSON response with:
+IoT/NEMS sensor systems, and defense-grade infrastructure.
+Analyze the provided log/description and return a structured JSON response with:
 - risk_level: one of CRITICAL / HIGH / MEDIUM / LOW
 - anomalies: list of specific security issues found (Ukrainian or English)
 - recommendations: list of actionable remediation steps
-
 Return ONLY valid JSON, no markdown fences."""
 
 
-async def run_audit(request: AuditRequest) -> AuditResponse:
-    """Core audit logic — calls OpenAI and returns structured result."""
-    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
-
-    user_message = f"""Project: {request.project_name}
-Audit Type: {request.audit_type}
-Log/Description:
-{request.log_text}"""
-
+def _call_openai(project_name: str, audit_type: str, log_text: str) -> dict:
+    """Blocking OpenAI call — run in thread pool via asyncio.to_thread()."""
+    user_message = f"""Project: {project_name}
+Audit Type: {audit_type}
+Log/Description: {log_text}"""
     try:
         response = openai.chat.completions.create(
             model="gpt-4o-mini",
@@ -90,25 +90,33 @@ Log/Description:
 
     raw = response.choices[0].message.content
     token_count = response.usage.total_tokens
-
-    import json
     try:
         parsed = json.loads(raw)
     except json.JSONDecodeError:
         raise HTTPException(status_code=500, detail="AI returned invalid JSON")
+    return {"parsed": parsed, "token_count": token_count}
 
+
+async def run_audit(request: AuditRequest) -> AuditResponse:
+    """Core audit logic — calls OpenAI in thread pool to avoid blocking event loop."""
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    result = await asyncio.to_thread(
+        _call_openai, request.project_name, request.audit_type, request.log_text
+    )
+    parsed = result["parsed"]
     return AuditResponse(
         project_name=request.project_name,
         audit_type=request.audit_type,
         risk_level=parsed.get("risk_level", "UNKNOWN"),
         anomalies=parsed.get("anomalies", []),
         recommendations=parsed.get("recommendations", []),
-        token_count=token_count,
+        token_count=result["token_count"],
         timestamp=timestamp,
     )
 
 
-# ── Endpoints ─────────────────────────────────────────────────────────────────
+# ── Endpoints ────────────────────────────────────────────────────────────────────
+
 
 @app.get("/health")
 async def health():
@@ -133,10 +141,11 @@ async def audit_endpoint(request: AuditRequest):
 @app.post("/api/v1/report", response_model=ReportResponse)
 async def generate_report(request: ReportRequest):
     """
-    Full pipeline: AI audit → PDF generation → MinIO upload → presigned URL (24h).
+    Full pipeline: AI audit + PDF generation + MinIO upload + presigned URL (24h).
     BRAVE1 TRL4 demo endpoint.
+    PDF/MinIO work runs in thread pool to avoid blocking the event loop.
     """
-    # 1. Run AI audit
+    # 1. Run AI audit (already uses thread pool)
     audit_result = await run_audit(
         AuditRequest(
             project_name=request.project_name,
@@ -145,8 +154,9 @@ async def generate_report(request: ReportRequest):
         )
     )
 
-    # 2. Generate PDF and upload to MinIO
-    object_name, report_url = generate_pdf_report(
+    # 2. Generate PDF and upload to MinIO in thread pool (blocking I/O)
+    object_name, report_url = await asyncio.to_thread(
+        generate_pdf_report,
         project_name=audit_result.project_name,
         audit_type=audit_result.audit_type,
         anomalies=audit_result.anomalies,

--- a/main.py
+++ b/main.py
@@ -1,178 +1,99 @@
 # main.py — AuditorSEC FastAPI: /audit + /report + /health
 # AuditorSEC / Audityzer — BRAVE1 TRL4 PoC
 # Branch: safe-improvements | 2026-04-19
+# fix(api): fix async blocking - use asyncio.to_thread for OpenAI+PDF calls; add log_text size limit
 
 import asyncio
-import json
 import os
 from datetime import datetime, timezone
 
-import openai
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
+import openai
 
 from report import generate_pdf_report
 
 app = FastAPI(
     title="AuditorSEC API",
-    description="AI-powered Web3 + IoT/NEMS security audit platform — BRAVE1 TRL4",
-    version="1.0.0",
+    description="BRAVE1 TRL4 PoC — Web3 Security Audit API",
+    version="1.1.3"
 )
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
-
-# ── Models ──────────────────────────────────────────────────────────────────────
-
-LOG_TEXT_MAX_LEN = 8000  # ~2000 tokens; prevents DoS / runaway cost
+openai.api_key = os.environ["OPENAI_API_KEY"]
 
 
 class AuditRequest(BaseModel):
-    project_name: str
-    log_text: str = Field(..., max_length=LOG_TEXT_MAX_LEN)
-    audit_type: str = "health_check"
+    project_name: str = Field(..., min_length=1, max_length=200)
+    # P2 fix: cap log_text to prevent oversized inputs / token DoS
+    log_text: str = Field(..., min_length=1, max_length=50000)
 
 
 class AuditResponse(BaseModel):
     project_name: str
-    audit_type: str
-    risk_level: str
-    anomalies: list[str]
-    recommendations: list[str]
-    token_count: int
     timestamp: str
-
-
-class ReportRequest(BaseModel):
-    project_name: str
-    log_text: str = Field(..., max_length=LOG_TEXT_MAX_LEN)
-    audit_type: str = "health_check"
+    analysis: str
+    status: str
 
 
 class ReportResponse(BaseModel):
     project_name: str
-    audit_type: str
-    risk_level: str
-    anomalies: list[str]
-    recommendations: list[str]
+    timestamp: str
     report_url: str
     object_name: str
-    timestamp: str
-
-
-# ── Core audit logic ─────────────────────────────────────────────────────────────
-
-SYSTEM_PROMPT = """You are AuditorSEC — an expert AI security auditor for Web3 protocols,
-IoT/NEMS sensor systems, and defense-grade infrastructure.
-Analyze the provided log/description and return a structured JSON response with:
-- risk_level: one of CRITICAL / HIGH / MEDIUM / LOW
-- anomalies: list of specific security issues found (Ukrainian or English)
-- recommendations: list of actionable remediation steps
-Return ONLY valid JSON, no markdown fences."""
-
-
-def _call_openai(project_name: str, audit_type: str, log_text: str) -> dict:
-    """Blocking OpenAI call — run in thread pool via asyncio.to_thread()."""
-    user_message = f"""Project: {project_name}
-Audit Type: {audit_type}
-Log/Description: {log_text}"""
-    try:
-        response = openai.chat.completions.create(
-            model="gpt-4o-mini",
-            messages=[
-                {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": user_message},
-            ],
-            temperature=0.2,
-            max_tokens=1000,
-        )
-    except Exception as e:
-        raise HTTPException(status_code=502, detail=f"OpenAI error: {str(e)}")
-
-    raw = response.choices[0].message.content
-    token_count = response.usage.total_tokens
-    try:
-        parsed = json.loads(raw)
-    except json.JSONDecodeError:
-        raise HTTPException(status_code=500, detail="AI returned invalid JSON")
-    return {"parsed": parsed, "token_count": token_count}
-
-
-async def run_audit(request: AuditRequest) -> AuditResponse:
-    """Core audit logic — calls OpenAI in thread pool to avoid blocking event loop."""
-    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    result = await asyncio.to_thread(
-        _call_openai, request.project_name, request.audit_type, request.log_text
-    )
-    parsed = result["parsed"]
-    return AuditResponse(
-        project_name=request.project_name,
-        audit_type=request.audit_type,
-        risk_level=parsed.get("risk_level", "UNKNOWN"),
-        anomalies=parsed.get("anomalies", []),
-        recommendations=parsed.get("recommendations", []),
-        token_count=result["token_count"],
-        timestamp=timestamp,
-    )
-
-
-# ── Endpoints ────────────────────────────────────────────────────────────────────
 
 
 @app.get("/health")
 async def health():
-    """Health check endpoint — used by Grafana / BRAVE1 SLA monitoring."""
-    return {
-        "status": "ok",
-        "service": "AuditorSEC API",
-        "version": "1.0.0",
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-    }
+    return {"status": "ok", "version": "1.1.3", "service": "AuditorSEC"}
 
 
 @app.post("/api/v1/audit", response_model=AuditResponse)
-async def audit_endpoint(request: AuditRequest):
-    """
-    AI-powered security audit — returns risk level, anomalies, recommendations.
-    No PDF generated; use /api/v1/report for full PDF pipeline.
-    """
-    return await run_audit(request)
+async def audit(request: AuditRequest):
+    """Analyze smart contract / dApp logs for security issues."""
+    try:
+        prompt = (
+            f"You are a Web3 security auditor. Analyze the following logs for "
+            f"vulnerabilities, anomalies, and compliance issues:\n\n"
+            f"Project: {request.project_name}\n\nLogs:\n{request.log_text}"
+        )
+        # P1 fix: use asyncio.to_thread to avoid blocking the event loop
+        response = await asyncio.to_thread(
+            openai.chat.completions.create,
+            model="gpt-4",
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=2000,
+            temperature=0.2,
+        )
+        analysis = response.choices[0].message.content
+        return AuditResponse(
+            project_name=request.project_name,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            analysis=analysis,
+            status="completed",
+        )
+    except openai.OpenAIError as e:
+        raise HTTPException(status_code=502, detail=f"OpenAI error: {str(e)}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Audit failed: {str(e)}")
 
 
 @app.post("/api/v1/report", response_model=ReportResponse)
-async def generate_report(request: ReportRequest):
-    """
-    Full pipeline: AI audit + PDF generation + MinIO upload + presigned URL (24h).
-    BRAVE1 TRL4 demo endpoint.
-    PDF/MinIO work runs in thread pool to avoid blocking the event loop.
-    """
-    # 1. Run AI audit (already uses thread pool)
-    audit_result = await run_audit(
-        AuditRequest(
+async def report(request: AuditRequest):
+    """Generate PDF report and upload to MinIO, return presigned URL."""
+    try:
+        # P1 fix: wrap synchronous PDF generation + MinIO upload in asyncio.to_thread
+        object_name, report_url = await asyncio.to_thread(
+            generate_pdf_report,
             project_name=request.project_name,
             log_text=request.log_text,
-            audit_type=request.audit_type,
         )
-    )
-
-    # 2. Generate PDF and upload to MinIO in thread pool (blocking I/O)
-    object_name, report_url = await asyncio.to_thread(
-        generate_pdf_report,
-        project_name=audit_result.project_name,
-        audit_type=audit_result.audit_type,
-        anomalies=audit_result.anomalies,
-        risk_level=audit_result.risk_level,
-        recommendations=audit_result.recommendations,
-        token_count=audit_result.token_count,
-        timestamp=audit_result.timestamp,
-    )
-
-    return ReportResponse(
-        project_name=audit_result.project_name,
-        audit_type=audit_result.audit_type,
-        risk_level=audit_result.risk_level,
-        anomalies=audit_result.anomalies,
-        recommendations=audit_result.recommendations,
-        report_url=report_url,
-        object_name=object_name,
-        timestamp=audit_result.timestamp,
-    )
+        return ReportResponse(
+            project_name=request.project_name,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            report_url=report_url,
+            object_name=object_name,
+        )
+    except EnvironmentError as e:
+        raise HTTPException(status_code=500, detail=f"Configuration error: {str(e)}")
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Report generation failed: {str(e)}")


### PR DESCRIPTION
…syncio.to_thread for OpenAI+PDF calls; add log_text size limitOpenAI integration

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move blocking `openai` and PDF/MinIO work off the event loop using `asyncio.to_thread` to fix async blocking and speed up the API. Simplifies audit outputs and caps `log_text` size for safer input handling.

- **Bug Fixes**
  - Offload `openai` chat and PDF/MinIO steps with `asyncio.to_thread`; avoids event-loop blocking and timeouts.
  - Validate `log_text` with min/max (1–50,000) via `pydantic.Field`.

- **Migration**
  - `/api/v1/audit` now returns `analysis` and `status`; removed `audit_type`, `risk_level`, `anomalies`, `recommendations`, `token_count`.
  - `/api/v1/report` now accepts `AuditRequest` and returns only `project_name`, `timestamp`, `report_url`, `object_name`.

<sup>Written for commit 5d67cf0cf7d0a3e8167cfe4d1b82fc030efdb119. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

