### PR TITLE
fix(docs): apply cubic-dev-ai P2 suggestions — BRAVE1 tier clarificat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,11 @@ Audityzer integrates with **AuditorSEC** — an AI-assisted compliance and secur
 > AuditorSEC MVP is a running FastAPI microservice with Dockerized deployment on a production-grade VPS (PostgreSQL, Redis cache, MinIO object storage). The `/api/v1/audit` and `/api/v1/report` endpoints are live and can be integrated into defense and fintech infrastructures as a standalone compliance engine.
 
 **BRAVE1 Roadmap:**
-The BRAVE1 roadmap targets Tier 3 (UAH 2M) with TRL 4-5 validation and phased scaling to Tier 4a/4b, using AuditorSEC as the core security and compliance layer for defense-grade systems.
+The BRAVE1 roadmap targets an initial Tier 3 tranche (UAH 2M) within the broader 8,000,000 UAH 2026 BRAVE1 program, with TRL 4-5 validation and phased scaling to Tier 4a/4b using AuditorSEC as the core security and compliance layer for defense-grade systems.
 
 | Timeline | Milestone | TRL |
 |----------|-----------|-----|
-| Now | MVP deployed: `/audit` + `/report` | **4** |
+| Now | MVP deployed: `/api/v1/audit` + `/api/v1/report` | **4** |
 | May 2026 | Defense/crypto pilot audits | **5** |
 | Q3 2026 | Multi-site deployments + PQC | **6** |
 


### PR DESCRIPTION
Fixes 2 P2 issues flagged by cubic-dev-ai in PR #156:

1. Clarified BRAVE1 Tier 3 (UAH 2M) as initial tranche within the broader 8,000,000 UAH 2026 BRAVE1 program
2. Updated roadmap table row 'Now' to use full API paths `/api/v1/audit` + `/api/v1/report` matching integration description

Closes cubic-dev-ai review issues on #156

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies the BRAVE1 roadmap: Tier 3 (UAH 2M) is the initial tranche within the 8,000,000 UAH 2026 program, and updates the "Now" row to use full API paths `/api/v1/audit` and `/api/v1/report`. Addresses two P2 doc issues flagged by `cubic-dev-ai` on PR #156.

<sup>Written for commit f29aa530fe8ada6e278652b510c7dd3527e8aca1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

