### PR TITLE
fix(gtm): convert BRAVE1 market figures to USD — resolve cubic P2 review

### DIFF
--- a/docs/COMPETITIVE_MATRIX.md
+++ b/docs/COMPETITIVE_MATRIX.md
@@ -77,8 +77,8 @@ manual audit firms (slow/expensive) and basic static scanners (no AI, no reports
 |---|---|---|---|
 | DeFi Security Audits | $2.1B | $180M | $1.8M |
 | VASP Compliance (BRICS) | $850M | $120M | $600K |
-| Defense/BRAVE1 | UAH 100M | UAH 8M | UAH 2M |
-| **Total** | **~$3B** | **~$300M** | **~$2.4M** |
+| Defense/BRAVE1 | ~$2.5M (UAH 100M) | ~$0.2M (UAH 8M) | ~$50K (UAH 2M) |
+| **Total** | **~$3B** (all USD) | **~$300M** (all USD) | **~$2.45M** (all USD) |
 
 *Source estimates: DeFiLlama security spend data, BRAVE1 program docs, FIU-IND reports 2025*
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Converted BRAVE1/Defense figures from UAH to USD in the Competitive Matrix and labeled totals as “all USD” for consistent currency across the table. Updated entries to ~$2.5M (UAH 100M), ~$0.2M (UAH 8M), ~$50K (UAH 2M), and the subtotal to ~$2.45M.

<sup>Written for commit c8d026408874e99c5d8e05e51e1c704a6681f8fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

