### PR TITLE
fix(conflict): sync netlify.toml with main — CSP img-src + full headers

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = "pnpm install --no-frozen-lockfile && pnpm run build"
   publish = "dist"
-  
+
 [build.environment]
   NODE_VERSION = "18"
   GIT_LFS_ENABLED = "false"
@@ -29,7 +29,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "strict-origin-when-cross-origin"
-    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:;"
+    Content-Security-Policy = "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' data: https:; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:;"
 
 [[headers]]
   for = "/assets/*"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Synced `netlify.toml` with main and updated the Content-Security-Policy to add `img-src 'self' data: https:` so images load from our domain, data URIs, and HTTPS sources. This prevents blocked images in production and aligns headers across branches.

<sup>Written for commit 3682cb8eeb504cd075882f71514a769e10bbd130. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

