### PR TITLE
feat(workflow): Optimism Chain Security Scanner — Stream D Sprint 260h microtask

### DIFF
--- a/.github/workflows/optimism-scan.yml
+++ b/.github/workflows/optimism-scan.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   CHAIN_ID: '10'
+  RPC_URL: 'https://mainnet.optimism.io'
 
 jobs:
   optimism-scan:
@@ -34,62 +35,57 @@ jobs:
           python-version: '3.11'
 
       - name: Install Slither
-        run: pip install slither-analyzer
+        run: pip install slither-analyzer==0.10.4
 
-      - name: Install Foundry
-        uses: foundry-rs/foundry-toolchain@v1
+      - name: Install Node dependencies
+        run: npm ci --prefer-offline
+
+      - name: Run Slither on Optimism contracts
+        id: slither
+        run: |
+          slither . \
+            --checklist \
+            --sarif slither-results.sarif \
+            --exclude-dependencies \
+            --filter-paths 'node_modules|test' \
+            2>&1 | tee slither-output.txt || true
+
+      - name: Upload Slither SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
         with:
-          version: nightly
+          sarif_file: slither-results.sarif
+          category: slither-optimism
 
-      - name: Scan Solidity contracts with Slither
-        run: |
-          echo "=== Optimism Chain Scan: $(date -u) ==="
-          if [ -d "contracts" ]; then
-            slither contracts/ \
-              --json slither-optimism-report.json \
-              --checklist --no-fail-pedantic \
-              2>&1 | tee slither-output.txt || true
-          else
-            echo "No contracts/ directory - skipping Slither"
-            echo '{"success":true,"results":{"detectors":[]}}' > slither-optimism-report.json
-          fi
-
-      - name: Run Foundry fork tests on Optimism
+      - name: Run Audityzer chain scan
         env:
-          OPTIMISM_RPC: ${{ secrets.OPTIMISM_RPC_URL }}
+          CHAIN_ID: ${{ env.CHAIN_ID }}
+          RPC_URL: ${{ env.RPC_URL }}
+          SCAN_DEPTH: ${{ github.event.inputs.scan_depth || 'quick' }}
         run: |
-          if [ -f "foundry.toml" ] && [ -n "$OPTIMISM_RPC" ]; then
-            forge test \
-              --fork-url "$OPTIMISM_RPC" \
-              --fork-block-number latest \
-              2>&1 | tee foundry-optimism-output.txt || true
-          else
-            echo "Skipping Foundry: no foundry.toml or OPTIMISM_RPC_URL not set"
-            echo 'Skipped' > foundry-optimism-output.txt
-          fi
+          node src/cli/index.js chain-scan \
+            --chain optimism \
+            --depth "$SCAN_DEPTH" \
+            --output scan-report.json
 
-      - name: Summarize results
-        run: |
-          echo "## Optimism Scan Results" >> $GITHUB_STEP_SUMMARY
-          echo "Chain: Optimism (ID: $CHAIN_ID) | $(date -u)" >> $GITHUB_STEP_SUMMARY
-          if [ -f slither-optimism-report.json ]; then
-            python3 -c "
-import json
-data = json.load(open('slither-optimism-report.json'))
-d = data.get('results',{}).get('detectors',[])
-high = sum(1 for x in d if x.get('impact')=='High')
-med = sum(1 for x in d if x.get('impact')=='Medium')
-print(f'High: {high} | Medium: {med} | Total: {len(d)}')
-" >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo 'Could not parse report' >> $GITHUB_STEP_SUMMARY
-          fi
-
-      - name: Upload artifacts
+      - name: Upload scan report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: optimism-scan-${{ github.run_number }}
+          name: optimism-scan-report-${{ github.run_number }}
           path: |
-            slither-optimism-report.json
+            scan-report.json
             slither-output.txt
-            foundry-optimism-output.txt
           retention-days: 30
+
+      - name: Post summary
+        if: always()
+        run: |
+          echo '## Optimism Chain Security Scan' >> $GITHUB_STEP_SUMMARY
+          echo "- Chain ID: $CHAIN_ID" >> $GITHUB_STEP_SUMMARY
+          echo "- Depth: ${{ github.event.inputs.scan_depth || 'quick' }}" >> $GITHUB_STEP_SUMMARY
+          echo "- Run: #${{ github.run_number }}" >> $GITHUB_STEP_SUMMARY
+          if [ -f slither-output.txt ]; then
+            ISSUES=$(grep -c 'Reference:' slither-output.txt || echo 0)
+            echo "- Slither issues: $ISSUES" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/optimism-scan.yml
+++ b/.github/workflows/optimism-scan.yml
@@ -1,0 +1,95 @@
+# optimism-scan.yml — AuditorSEC Optimism Chain Security Scanner
+# Stream D (Potik D) — Sprint 260h Monday microtask
+name: Optimism Chain Security Scan
+
+on:
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+    inputs:
+      scan_depth:
+        description: 'quick | full'
+        required: false
+        default: 'quick'
+
+env:
+  CHAIN_ID: '10'
+
+jobs:
+  optimism-scan:
+    name: Optimism Security Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Slither
+        run: pip install slither-analyzer
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Scan Solidity contracts with Slither
+        run: |
+          echo "=== Optimism Chain Scan: $(date -u) ==="
+          if [ -d "contracts" ]; then
+            slither contracts/ \
+              --json slither-optimism-report.json \
+              --checklist --no-fail-pedantic \
+              2>&1 | tee slither-output.txt || true
+          else
+            echo "No contracts/ directory - skipping Slither"
+            echo '{"success":true,"results":{"detectors":[]}}' > slither-optimism-report.json
+          fi
+
+      - name: Run Foundry fork tests on Optimism
+        env:
+          OPTIMISM_RPC: ${{ secrets.OPTIMISM_RPC_URL }}
+        run: |
+          if [ -f "foundry.toml" ] && [ -n "$OPTIMISM_RPC" ]; then
+            forge test \
+              --fork-url "$OPTIMISM_RPC" \
+              --fork-block-number latest \
+              2>&1 | tee foundry-optimism-output.txt || true
+          else
+            echo "Skipping Foundry: no foundry.toml or OPTIMISM_RPC_URL not set"
+            echo 'Skipped' > foundry-optimism-output.txt
+          fi
+
+      - name: Summarize results
+        run: |
+          echo "## Optimism Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "Chain: Optimism (ID: $CHAIN_ID) | $(date -u)" >> $GITHUB_STEP_SUMMARY
+          if [ -f slither-optimism-report.json ]; then
+            python3 -c "
+import json
+data = json.load(open('slither-optimism-report.json'))
+d = data.get('results',{}).get('detectors',[])
+high = sum(1 for x in d if x.get('impact')=='High')
+med = sum(1 for x in d if x.get('impact')=='Medium')
+print(f'High: {high} | Medium: {med} | Total: {len(d)}')
+" >> $GITHUB_STEP_SUMMARY 2>/dev/null || echo 'Could not parse report' >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: optimism-scan-${{ github.run_number }}
+          path: |
+            slither-optimism-report.json
+            slither-output.txt
+            foundry-optimism-output.txt
+          retention-days: 30


### PR DESCRIPTION
## Stream D (Potik D) — Sprint 260h Monday Microtask

### Summary
Complete GitHub Actions workflow for Optimism Chain security scanning.

### Changes
- `optimism-scan.yml` — full workflow with Slither SARIF upload, Audityzer chain-scan CLI, artifact upload, step summary
- Scheduled weekly (Mon 06:00 UTC) + `workflow_dispatch` with `scan_depth` input
- Permissions: `contents: read`, `security-events: write`
- CodeQL-compatible SARIF output via `github/codeql-action/upload-sarif@v3`

### Test plan
- [ ] Manual trigger via `workflow_dispatch` with `scan_depth=quick`
- [ ] Verify SARIF appears in Security tab
- [ ] Artifact `optimism-scan-report-*` uploaded successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scheduled and on-demand GitHub Actions workflow to scan Optimism contracts with Slither and the Audityzer chain scanner. Results are uploaded to the Security tab (SARIF) and as artifacts, with a short run summary.

- **New Features**
  - Adds optimism scan workflow running Mondays 06:00 UTC and `workflow_dispatch` with `scan_depth` (`quick`/`full`).
  - Runs Slither with SARIF and uploads via `github/codeql-action/upload-sarif@v3`.
  - Executes Audityzer `chain-scan` for Optimism (`CHAIN_ID` 10, `RPC_URL` `https://mainnet.optimism.io`) to produce `scan-report.json`.
  - Uploads `scan-report.json` and `slither-output.txt` via `actions/upload-artifact@v4` and posts a step summary.
  - Sets permissions (`contents: read`, `security-events: write`), uses `actions/checkout@v4`, `actions/setup-python@v5`, installs `slither-analyzer==0.10.4`, and runs `npm ci`.

<sup>Written for commit 923f9fe5cf6b29d58a9ac5b04bd68564f36d2daa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

