### PR TITLE
fix(submodules): add .gitmodules to fix Netlify deploy — audityzer-co…

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,11 @@
+[submodule "audityzer-core"]
+	path = audityzer-core
+	url = https://github.com/romanchaa997/Audityzer.git
+
+[submodule "audityzer-platform"]
+	path = audityzer-platform
+	url = https://github.com/romanchaa997/Audityzer.git
+
+[submodule "web-platform"]
+	path = web-platform
+	url = https://github.com/romanchaa997/Audityzer.git


### PR DESCRIPTION
…re/platform/web-platform URLs

Netlify deploy fails with:
  fatal: No url found for submodule path 'audityzer-core' in .gitmodules

Root cause: audityzer-core, audityzer-platform, web-platform are registered as git submodule gitlinks in the tree but .gitmodules was missing.

Fix: add .gitmodules pointing these paths at the main Audityzer repo URL. This unblocks Netlify deploy previews for all open PRs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a .gitmodules file defining submodules `audityzer-core`, `audityzer-platform`, and `web-platform` to resolve Netlify deploy failures caused by missing submodule URLs. This restores deploy previews for all PRs.

<sup>Written for commit 8debb491c1d57cdfbd10918b3cb2701eb7b365b5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

