### PR TITLE
fix(netlify): add GIT_SUBMODULE_STRATEGY=none to skip broken gitlinks

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -6,6 +6,7 @@
   NODE_VERSION = "18"
   GIT_LFS_ENABLED = "false"
   PNPM_FLAGS = "--no-frozen-lockfile"
+    GIT_SUBMODULE_STRATEGY = "none"
 
 # Build settings with correct pnpm commands
 [context.production]


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable submodule checkout in Netlify builds by setting `GIT_SUBMODULE_STRATEGY="none"` in netlify.toml. This skips broken gitlinks and prevents build failures.

<sup>Written for commit 2d24cd3ee01ee56b35008c6b364350f841b943db. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

