### PR TITLE
fix(workflow): remove empty with: block in foundry-fuzz checkout step

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -89,10 +89,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-        with:
-  
-
-      - name: Install Foundry
+        - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
       - name: Check for Foundry project


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the empty `with:` block from the `actions/checkout@v4` step in `.github/workflows/security-scan.yml` to keep the workflow valid and prevent warnings.

<sup>Written for commit 96e97eb1e157cd667fb758c935b7316d062cd0ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

