### PR TITLE
fix(workflow): fix YAML indentation for run key in Setup pnpm step

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -34,7 +34,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-                run: npm install -g pnpm@9
+          run: npm install -g pnpm@9
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix YAML indentation for the run key in the "Setup pnpm" step of the deploy workflow so GitHub Actions parses it correctly and installs `pnpm@9`. Prevents the step from being skipped and ensures dependencies install with `pnpm`.

<sup>Written for commit 610f08ec95461d3f42ce9980db48f43d8294199b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

