### PR TITLE
fix(docker): add trailing slash to server.js COPY — resolve PR #153 c…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY --chown=audityzer:audityzer src/ ./src/
 COPY --chown=audityzer:audityzer bin/ ./bin/
 COPY --chown=audityzer:audityzer templates/ ./templates/
 COPY --chown=audityzer:audityzer lib/ ./lib/
-COPY --chown=audityzer:audityzer server.js .
+COPY --chown=audityzer:audityzer server.js ./
 COPY --chown=audityzer:audityzer scripts/healthcheck.sh scripts/start.sh ./scripts/
 
 # Make scripts executable and fix line endings


### PR DESCRIPTION
…onflict

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Docker build by copying server.js explicitly into the working directory. Adds a trailing slash to the COPY target to avoid path ambiguity and prevent build failures.

<sup>Written for commit 7f9f5e671b6ab432e224654a489c2064b7fe819f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

