### PR TITLE
fix(ci): remove npm cache from promptfoo workflow - no package-lock.json

### DIFF
--- a/.github/workflows/promptfoo-ai-security.yml
+++ b/.github/workflows/promptfoo-ai-security.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
-          cache: 'npm'
+        
 
       - name: Install promptfoo
         run: npm install -g promptfoo


### PR DESCRIPTION
Removed caching for npm in Node.js setup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed npm caching from `actions/setup-node` in the `promptfoo` CI workflow because there's no `package-lock.json`. This avoids ineffective cache restores and setup warnings.

<sup>Written for commit 39f8e2f098dedef37fc5108463b6f70d4be302fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

