### PR TITLE
feat(deploy): add vercel.json - Vite SPA config + security headers

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,27 @@
+{
+  "version": 2,
+  "buildCommand": "pnpm install --no-frozen-lockfile && pnpm run build",
+  "outputDirectory": "dist",
+  "installCommand": "pnpm install --no-frozen-lockfile",
+  "framework": "vite",
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  },
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add `vercel.json` to deploy the `vite` SPA on Vercel with proper routing and stronger security headers. This ensures reliable builds on Vercel and a safer default setup.

- New Features
  - Vercel v2 config with `framework: "vite"`, `outputDirectory: "dist"`, and `pnpm` install/build commands.
  - Git auto-deploys enabled for `main`.
  - SPA routing: rewrite all paths to `/index.html`.
  - Security headers: `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`, `Permissions-Policy: camera=(), microphone=(), geolocation=()`.

<sup>Written for commit 3ab13e52e55f2e46921dfce792628a0b4ab32748. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

