### PR TITLE
fix(ci): intel-monitor Node.js 20→22 + fetch-depth:0 for Semgrep git fix

### DIFF
--- a/.github/workflows/intel-monitor.yml
+++ b/.github/workflows/intel-monitor.yml
@@ -16,11 +16,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+                with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
 
       - name: Install security tools
         run: |


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps Node.js to 22 in the `intel-monitor` workflow and checks out the full git history (`fetch-depth: 0`) to fix Semgrep’s git-based analysis.

<sup>Written for commit 75b5bca777395fbabbcf7a10320eb673ecf11b00. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

