### PR TITLE
fix(deploy): add .gitmodules - fix Netlify/Vercel submodule checkout …

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,9 @@
+[submodule "audityzer-core"]
+	path = audityzer-core
+	url = https://github.com/romanchaa997/Audityzer.git
+	ignore = all
+	
+[submodule "audityzer-platform"]
+	path = audityzer-platform
+	url = https://github.com/romanchaa997/Audityzer.git
+	ignore = all


### PR DESCRIPTION
Adds .gitmodules with valid URLs for audityzer-core and audityzer-platform submodules to fix Netlify/Vercel clone initialization errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add .gitmodules to define `audityzer-core` and `audityzer-platform` submodules, fixing submodule checkout errors on Netlify/Vercel. This ensures deploys and CI fetch submodules consistently.

- **Migration**
  - After pulling, run: git submodule sync --recursive && git submodule update --init --recursive
  - In Netlify/Vercel, enable submodule cloning or call git submodule update in the build command

<sup>Written for commit fbacd82b9e681d870c191ad73c7d07defe454502. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

